### PR TITLE
fix potential bug when deal with non-ascii files

### DIFF
--- a/url_checker.pl
+++ b/url_checker.pl
@@ -1,5 +1,6 @@
 #!/usr/bin/env perl
 
+use utf8;
 use warnings;
 use strict;
 use LWP::UserAgent;
@@ -17,7 +18,7 @@ my %db;
 #read all the contents of each *.md file inside @books and put it into %db
 foreach my $book (sort @books){
 	local $/ = undef;
-	open FILE, "$book" or die "Couldn't open file: $!";
+	open FILE, '<:encoding(UTF-8)', "$book" or die "Couldn't open file: $!";
 	my $content = <FILE>;
 	close FILE;
 	$db{$book}{"content"}=$content;


### PR DESCRIPTION
when use URI::Find::UTF8 module to extrace urls, but forgot to specify input file encoding to utf8.
This will produce some wrong result. I try to fix it by specifing encoding parameter for perl open function.  hope it will work